### PR TITLE
Added support for package.* being directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ portage_make:
       - en
       - es
 ```
+- `portage_ansible_managed_filename`: in case paths like `/etc/portage/package.accept_keywords` are a directory, a file with this name will be created in the corresponding path to include the requested line. [Default: `ansible_managed`]
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -11,15 +11,19 @@ Role Variables
 portage_accept_keywords:
   - atom: app-admin/ansible
     keyword: ~amd64
+    name: some_filename
 ```
+    If `name` is specified, file with that name is created inside the `portage.accept_keywords` directory.
 - `portage_accept_license`: List of licenses to accept. Example:
 ```yaml
 portage_accept_license:
   - atom: app-editors/visual-studio-code
     license: MS-vscode-EULA license
+    name: some_filename
 ```
-- `portage_unmask`: List of lines to add to `package.unmask` file.
-- `portage_mask`: List of lines to add to `package.mask` file.
+    If `name` is specified, file with that name is created inside the `portage.accept_license` directory.
+- `portage_unmask`: List of lines to add to `package.unmask` file or to a file inside that directory.
+- `portage_mask`: List of lines to add to `package.mask` file or to a file inside that directory.
 - `portage_sets`: List of sets to create, each set is also added to `world_sets`. Example:
 ```yaml
 portage_sets:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,3 +8,4 @@ portage_sets: []
 portage_package_use: []
 portage_world: []
 portage_make: []
+portage_ansible_managed_filename: "ansible_managed"

--- a/tasks/accept_keyword.yml
+++ b/tasks/accept_keyword.yml
@@ -1,15 +1,22 @@
-- name: Set target path
+- name: Set default target path
   set_fact:
     target_path: "/etc/portage/package.accept_keywords"
+
+- name: Set target path if provided
+  set_fact:
+    target_path: "{{ target_path }}/{{ package_accept_keywords.name }}"
+  when: package_accept_keywords.name is defined
 
 - name: Check if the target path is a directory and adjust it
   include_tasks:
     file: check_if_dir.yml
+  when: package_accept_keywords.name is not defined
 
-- name: "Accept \"{{ item.keyword }}\" for \"{{ item.atom }}\" atom"
+
+- name: "Accept \"{{ package_accept_keywords.keyword }}\" for \"{{ package_accept_keywords.atom }}\" atom"
   ansible.builtin.lineinfile:
     path: "{{ target_path }}"
-    line: "{{ item.atom }} {{ item.keyword }}"
+    line: "{{ package_accept_keywords.atom }} {{ package_accept_keywords.keyword }}"
     create: yes
     owner: root
     group: root

--- a/tasks/accept_keyword.yml
+++ b/tasks/accept_keyword.yml
@@ -1,6 +1,14 @@
+- name: Set target path
+  set_fact:
+    target_path: "/etc/portage/package.accept_keywords"
+
+- name: Check if the target path is a directory and adjust it
+  include_tasks:
+    file: check_if_dir.yml
+
 - name: "Accept \"{{ item.keyword }}\" for \"{{ item.atom }}\" atom"
   ansible.builtin.lineinfile:
-    path: /etc/portage/package.accept_keywords
+    path: "{{ target_path }}"
     line: "{{ item.atom }} {{ item.keyword }}"
     create: yes
     owner: root

--- a/tasks/accept_license.yml
+++ b/tasks/accept_license.yml
@@ -1,15 +1,21 @@
-- name: Set target path
+- name: Set default target path
   set_fact:
     target_path: "/etc/portage/package.license"
+
+- name: Set target path if provided
+  set_fact:
+    target_path: "{{ target_path }}/{{ package_accept_license.name }}"
+  when: package_accept_license.name is defined
 
 - name: Check if the target path is a directory and adjust it
   include_tasks:
     file: check_if_dir.yml
+  when: package_accept_license.name is not defined
 
-- name: "Accept \"{{ item.license }}\" for \"{{ item.atom }}\" atom"
+- name: "Accept \"{{ package_accept_license.license }}\" for \"{{ package_accept_license.atom }}\" atom"
   ansible.builtin.lineinfile:
     path: "{{ target_path }}"
-    line: "{{ item.atom }} {{ item.license }}"
+    line: "{{ package_accept_license.atom }} {{ package_accept_license.license }}"
     create: yes
     owner: root
     group: root

--- a/tasks/accept_license.yml
+++ b/tasks/accept_license.yml
@@ -1,6 +1,14 @@
+- name: Set target path
+  set_fact:
+    target_path: "/etc/portage/package.license"
+
+- name: Check if the target path is a directory and adjust it
+  include_tasks:
+    file: check_if_dir.yml
+
 - name: "Accept \"{{ item.license }}\" for \"{{ item.atom }}\" atom"
   ansible.builtin.lineinfile:
-    path: /etc/portage/package.license
+    path: "{{ target_path }}"
     line: "{{ item.atom }} {{ item.license }}"
     create: yes
     owner: root

--- a/tasks/check_if_dir.yml
+++ b/tasks/check_if_dir.yml
@@ -1,0 +1,11 @@
+# Mutates incoming target_path if needed. To be used for paths that could be directories
+- name: "Check if {{ target_path }} is a directory and determine the file"
+  block:
+    - name: Gather stat for directory
+      stat:
+        path: "{{ target_path }}"
+      register: _target_path_stat
+    - name: Set the path to file inside the directory
+      set_fact:
+        target_path: "{{ target_path }}/{{ portage_ansible_managed_filename }}"
+      when: _target_path_stat.stat.isdir

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,12 @@
 - include: accept_keyword.yml
   loop: "{{ portage_accept_keywords }}"
+  loop_control:
+    loop_var: package_accept_keywords
 
 - include: accept_license.yml
   loop: "{{ portage_accept_license }}"
+  loop_control:
+    loop_var: package_accept_license
 
 - include: unmask.yml
   loop: "{{ portage_unmask }}"

--- a/tasks/mask.yml
+++ b/tasks/mask.yml
@@ -1,6 +1,14 @@
+- name: Set target path
+  set_fact:
+    target_path: "/etc/portage/package.mask"
+
+- name: Check if the target path is a directory and adjust it
+  include_tasks:
+    file: check_if_dir.yml
+
 - name: "Mask \"{{ item }}\""
   ansible.builtin.lineinfile:
-    path: /etc/portage/package.mask
+    path: "{{ target_path }}"
     line: "{{ item }}"
     create: yes
     owner: root

--- a/tasks/unmask.yml
+++ b/tasks/unmask.yml
@@ -1,6 +1,14 @@
+- name: Set target path
+  set_fact:
+    target_path: "/etc/portage/package.unmask"
+
+- name: Check if the target path is a directory and adjust it
+  include_tasks:
+    file: check_if_dir.yml
+
 - name: "Unmask \"{{ item }}\" atom"
   ansible.builtin.lineinfile:
-    path: /etc/portage/package.unmask
+    path: "{{ target_path }}"
     line: "{{ item }}"
     create: yes
     owner: root

--- a/tasks/unmask.yml
+++ b/tasks/unmask.yml
@@ -1,4 +1,4 @@
-- name: Set target path
+- name: Set default target path
   set_fact:
     target_path: "/etc/portage/package.unmask"
 


### PR DESCRIPTION
In many cases package.* paths are actually directories (e.g. it's a strict requirement for cross-compilation). I have slightly changed the logic of tasks to check if the path is a directory. If it is - a file with the required information will be created inside those directories.

The individual commits provide more details on the changes.